### PR TITLE
feat: add dynamo block index migrator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -503,6 +503,455 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.410.0.tgz",
+      "integrity": "sha512-Uq5+ePGx+SnUMuCKMqhZ8q6hSHiWoBNpJXYr9fpL9zcZQ63chCBIOqOYw71OqKH8D89aRa8Y6G6dlt7/tW8CXQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.410.0",
+        "@aws-sdk/credential-provider-node": "3.410.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.410.0",
+        "@aws-sdk/middleware-host-header": "3.410.0",
+        "@aws-sdk/middleware-logger": "3.410.0",
+        "@aws-sdk/middleware-recursion-detection": "3.410.0",
+        "@aws-sdk/middleware-signing": "3.410.0",
+        "@aws-sdk/middleware-user-agent": "3.410.0",
+        "@aws-sdk/types": "3.410.0",
+        "@aws-sdk/util-endpoints": "3.410.0",
+        "@aws-sdk/util-user-agent-browser": "3.410.0",
+        "@aws-sdk/util-user-agent-node": "3.410.0",
+        "@smithy/config-resolver": "^2.0.7",
+        "@smithy/fetch-http-handler": "^2.1.2",
+        "@smithy/hash-node": "^2.0.6",
+        "@smithy/invalid-dependency": "^2.0.6",
+        "@smithy/middleware-content-length": "^2.0.8",
+        "@smithy/middleware-endpoint": "^2.0.6",
+        "@smithy/middleware-retry": "^2.0.9",
+        "@smithy/middleware-serde": "^2.0.6",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.9",
+        "@smithy/node-http-handler": "^2.1.2",
+        "@smithy/protocol-http": "^3.0.2",
+        "@smithy/smithy-client": "^2.1.3",
+        "@smithy/types": "^2.3.0",
+        "@smithy/url-parser": "^2.0.6",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.7",
+        "@smithy/util-defaults-mode-node": "^2.0.9",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/util-waiter": "^2.0.6",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sso": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.410.0.tgz",
+      "integrity": "sha512-MC9GrgwtlOuSL2WS3DRM3dQ/5y+49KSMMJRH6JiEcU5vE0dX/OtEcX+VfEwpi73x5pSfIjm7xnzjzOFx+sQBIg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.410.0",
+        "@aws-sdk/middleware-logger": "3.410.0",
+        "@aws-sdk/middleware-recursion-detection": "3.410.0",
+        "@aws-sdk/middleware-user-agent": "3.410.0",
+        "@aws-sdk/types": "3.410.0",
+        "@aws-sdk/util-endpoints": "3.410.0",
+        "@aws-sdk/util-user-agent-browser": "3.410.0",
+        "@aws-sdk/util-user-agent-node": "3.410.0",
+        "@smithy/config-resolver": "^2.0.7",
+        "@smithy/fetch-http-handler": "^2.1.2",
+        "@smithy/hash-node": "^2.0.6",
+        "@smithy/invalid-dependency": "^2.0.6",
+        "@smithy/middleware-content-length": "^2.0.8",
+        "@smithy/middleware-endpoint": "^2.0.6",
+        "@smithy/middleware-retry": "^2.0.9",
+        "@smithy/middleware-serde": "^2.0.6",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.9",
+        "@smithy/node-http-handler": "^2.1.2",
+        "@smithy/protocol-http": "^3.0.2",
+        "@smithy/smithy-client": "^2.1.3",
+        "@smithy/types": "^2.3.0",
+        "@smithy/url-parser": "^2.0.6",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.7",
+        "@smithy/util-defaults-mode-node": "^2.0.9",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sts": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.410.0.tgz",
+      "integrity": "sha512-e6VMrBJtnTxxUXwDmkADGIvyppmDMFf4+cGGA68tVCUm1cFNlCI6M/67bVSIPN/WVKAAfhEL5O2vVXCM7aatYg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/credential-provider-node": "3.410.0",
+        "@aws-sdk/middleware-host-header": "3.410.0",
+        "@aws-sdk/middleware-logger": "3.410.0",
+        "@aws-sdk/middleware-recursion-detection": "3.410.0",
+        "@aws-sdk/middleware-sdk-sts": "3.410.0",
+        "@aws-sdk/middleware-signing": "3.410.0",
+        "@aws-sdk/middleware-user-agent": "3.410.0",
+        "@aws-sdk/types": "3.410.0",
+        "@aws-sdk/util-endpoints": "3.410.0",
+        "@aws-sdk/util-user-agent-browser": "3.410.0",
+        "@aws-sdk/util-user-agent-node": "3.410.0",
+        "@smithy/config-resolver": "^2.0.7",
+        "@smithy/fetch-http-handler": "^2.1.2",
+        "@smithy/hash-node": "^2.0.6",
+        "@smithy/invalid-dependency": "^2.0.6",
+        "@smithy/middleware-content-length": "^2.0.8",
+        "@smithy/middleware-endpoint": "^2.0.6",
+        "@smithy/middleware-retry": "^2.0.9",
+        "@smithy/middleware-serde": "^2.0.6",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.9",
+        "@smithy/node-http-handler": "^2.1.2",
+        "@smithy/protocol-http": "^3.0.2",
+        "@smithy/smithy-client": "^2.1.3",
+        "@smithy/types": "^2.3.0",
+        "@smithy/url-parser": "^2.0.6",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.7",
+        "@smithy/util-defaults-mode-node": "^2.0.9",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.410.0.tgz",
+      "integrity": "sha512-c7TB9LbN0PkFOsXI0lcRJnqPNOmc4VBvrHf8jP/BkTDg4YUoKQKOFd4d0SqzODmlZiAyoMQVZTR4ISZo95Zj4Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.410.0.tgz",
+      "integrity": "sha512-D8rcr5bRCFD0f42MPQ7K6TWZq5d3pfqrKINL1/bpfkK5BJbvq1BGYmR88UC6CLpTRtZ1LHY2HgYG0fp/2zjjww==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.410.0",
+        "@aws-sdk/credential-provider-process": "3.410.0",
+        "@aws-sdk/credential-provider-sso": "3.410.0",
+        "@aws-sdk/credential-provider-web-identity": "3.410.0",
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.410.0.tgz",
+      "integrity": "sha512-0wmVm33T/j1FS7MZ/j+WsPlgSc0YnCXnpbWSov1Mn6R86SHI2b2JhdIPRRE4XbGfyW2QGNUl2CwoZVaqhXeF5g==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.410.0",
+        "@aws-sdk/credential-provider-ini": "3.410.0",
+        "@aws-sdk/credential-provider-process": "3.410.0",
+        "@aws-sdk/credential-provider-sso": "3.410.0",
+        "@aws-sdk/credential-provider-web-identity": "3.410.0",
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.410.0.tgz",
+      "integrity": "sha512-BMju1hlDCDNkkSZpKF5SQ8G0WCLRj6/Jvw9QmudLHJuVwYJXEW1r2AsVMg98OZ3hB9G+MAvHruHZIbMiNmUMXQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.410.0.tgz",
+      "integrity": "sha512-zEaoY/sY+KYTlQUkp9dvveAHf175b8RIt0DsQkDrRPtrg/RBHR00r5rFvz9+nrwsR8546RaBU7h/zzTaQGhmcA==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.410.0",
+        "@aws-sdk/token-providers": "3.410.0",
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.410.0.tgz",
+      "integrity": "sha512-cE0l8LmEHdWbDkdPNgrfdYSgp4/cIVXrjUKI1QCATA729CrHZ/OQjB/maOBOrMHO9YTiggko887NkslVvwVB7w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.410.0.tgz",
+      "integrity": "sha512-ED/OVcyITln5rrxnajZP+V0PN1nug+gSDHJDqdDo/oLy7eiDr/ZWn3nlWW7WcMplQ1/Jnb+hK0UetBp/25XooA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/protocol-http": "^3.0.2",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.410.0.tgz",
+      "integrity": "sha512-YtmKYCVtBfScq3/UFJk+aSZOktKJBNZL9DaSc2aPcy/goCVsYDOkGwtHk0jIkC1JRSNCkVTqL7ya60sSr8zaQQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.410.0.tgz",
+      "integrity": "sha512-KWaes5FLzRqj28vaIEE4Bimpga2E596WdPF2HaH6zsVMJddoRDsc3ZX9ZhLOGrXzIO1RqBd0QxbLrM0S/B2aOQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/protocol-http": "^3.0.2",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.410.0.tgz",
+      "integrity": "sha512-YfBpctDocRR4CcROoDueJA7D+aMLBV8nTFfmVNdLLLgyuLZ/AUR11VQSu1lf9gQZKl8IpKE/BLf2fRE/qV1ZuA==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.410.0",
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.410.0.tgz",
+      "integrity": "sha512-KBAZ/eoAJUSJv5us2HsKwK2OszG2s9FEyKpEhgnHLcbbKzW873zHBH5GcOGEQu4AWArTy2ndzJu3FF+9/J9hJQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.2",
+        "@smithy/signature-v4": "^2.0.0",
+        "@smithy/types": "^2.3.0",
+        "@smithy/util-middleware": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.410.0.tgz",
+      "integrity": "sha512-ZayDtLfvCZUohSxQc/49BfoU/y6bDHLfLdyyUJbJ54Sv8zQcrmdyKvCBFUZwE6tHQgAmv9/ZT18xECMl+xiONA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.410.0",
+        "@aws-sdk/util-endpoints": "3.410.0",
+        "@smithy/protocol-http": "^3.0.2",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/token-providers": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.410.0.tgz",
+      "integrity": "sha512-d5Nc0xydkH/X0LA1HDyhGY5sEv4LuADFk+QpDtT8ogLilcre+b1jpdY8Sih/gd1KoGS1H+d1tz2hSGwUHAbUbw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.410.0",
+        "@aws-sdk/middleware-logger": "3.410.0",
+        "@aws-sdk/middleware-recursion-detection": "3.410.0",
+        "@aws-sdk/middleware-user-agent": "3.410.0",
+        "@aws-sdk/types": "3.410.0",
+        "@aws-sdk/util-endpoints": "3.410.0",
+        "@aws-sdk/util-user-agent-browser": "3.410.0",
+        "@aws-sdk/util-user-agent-node": "3.410.0",
+        "@smithy/config-resolver": "^2.0.7",
+        "@smithy/fetch-http-handler": "^2.1.2",
+        "@smithy/hash-node": "^2.0.6",
+        "@smithy/invalid-dependency": "^2.0.6",
+        "@smithy/middleware-content-length": "^2.0.8",
+        "@smithy/middleware-endpoint": "^2.0.6",
+        "@smithy/middleware-retry": "^2.0.9",
+        "@smithy/middleware-serde": "^2.0.6",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.9",
+        "@smithy/node-http-handler": "^2.1.2",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.2",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/smithy-client": "^2.1.3",
+        "@smithy/types": "^2.3.0",
+        "@smithy/url-parser": "^2.0.6",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.7",
+        "@smithy/util-defaults-mode-node": "^2.0.9",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/types": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.410.0.tgz",
+      "integrity": "sha512-D7iaUCszv/v04NDaZUmCmekamy6VD/lKozm/3gS9+dkfU6cC2CsNoUfPV8BlV6dPdw0oWgF91am3I1stdvfVrQ==",
+      "dependencies": {
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.410.0.tgz",
+      "integrity": "sha512-iNiqJyC7N3+8zFwnXUqcWSxrZecVZLToo1iTQQdeYL2af1IcOtRgb7n8jpAI/hmXhBSx2+3RI+Y7pxyFo1vu+w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.410.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.410.0.tgz",
+      "integrity": "sha512-i1G/XGpXGMRT2zEiAhi1xucJsfCWk8nNYjk/LbC0sA+7B9Huri96YAzVib12wkHPsJQvZxZC6CpQDIHWm4lXMA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/types": "^2.3.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.410.0.tgz",
+      "integrity": "sha512-bK70t1jHRl8HrJXd4hEIwc5PBZ7U0w+81AKFnanIVKZwZedd6nLibUXDTK14z/Jp2GFcBqd4zkt2YLGkRt/U4A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/node-config-provider": "^2.0.9",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/protocol-http": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.2.tgz",
+      "integrity": "sha512-LUOWCPRihvJBkdSs+ivK9m1f/rMfF3n9Zpzg8qdry2eIG4HQqqLBMWQyF9bgk7JhsrrOa3//jJKhXzvL7wL5Xw==",
+      "dependencies": {
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@aws-sdk/client-ecs": {
       "version": "3.382.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecs/-/client-ecs-3.382.0.tgz",
@@ -1727,6 +2176,31 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.310.0.tgz",
+      "integrity": "sha512-y3wipforet41EDTI0vnzxILqwAGll1KfI5qcdX9pXF/WF1f+3frcOtPiWtQEZQpy4czRogKm3BHo70QBYAZxlQ==",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache/node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache/node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
+    },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
       "version": "3.391.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.391.0.tgz",
@@ -1749,6 +2223,45 @@
       "integrity": "sha512-QpYVFKMOnzHz/JMj/b8wb18qxiT92U/5r5MmtRz2R3LOH6ooTO96k4ozXCrYr0qNed1PAnOj73rPrrH2wnCJKQ==",
       "dependencies": {
         "@smithy/types": "^2.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.410.0.tgz",
+      "integrity": "sha512-XHX4IqsyF3yVmh7mgeq9HMg0bpUOMhO5659JF56MdyxZ8JPVZVsgWfJYmQ/hCMG850kvYXS2/8kxCjERrONQFA==",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "3.310.0",
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/protocol-http": "^3.0.2",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/types": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.410.0.tgz",
+      "integrity": "sha512-D7iaUCszv/v04NDaZUmCmekamy6VD/lKozm/3gS9+dkfU6cC2CsNoUfPV8BlV6dPdw0oWgF91am3I1stdvfVrQ==",
+      "dependencies": {
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@smithy/protocol-http": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.2.tgz",
+      "integrity": "sha512-LUOWCPRihvJBkdSs+ivK9m1f/rMfF3n9Zpzg8qdry2eIG4HQqqLBMWQyF9bgk7JhsrrOa3//jJKhXzvL7wL5Xw==",
+      "dependencies": {
+        "@smithy/types": "^2.3.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2371,6 +2884,17 @@
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.310.0.tgz",
       "integrity": "sha512-jL8509owp/xB9+Or0pvn3Fe+b94qfklc2yPowZZIFAkFcCSIdkIglz18cPDWnYAcy9JGewpMS1COXKIUhZkJsA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.410.0.tgz",
+      "integrity": "sha512-BHsiggDcotKWUgbv/ZIYGNRzGzkDnek7IRjyZJc/Bl7uA6EnOKAWDS86z+CjnEI9H0vbDnvihLiANdjEcNOa0w==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -3548,11 +4072,11 @@
       "dev": true
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.4.tgz",
-      "integrity": "sha512-3+3/xRQ0K/NFVtKSiTGsUa3muZnVaBmHrLNgxwoBLZO9rNhwZtjjjf7pFJ6aoucoul/c/w3xobRkgi8F9MWX8Q==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.6.tgz",
+      "integrity": "sha512-4I7g0lyGUlW2onf8mD76IzU37oRWSHsQ5zlW5MjDzgg4I4J9bOK4500Gx6qOuoN7+GulAnGLe1YwyrIluzhakg==",
       "dependencies": {
-        "@smithy/types": "^2.2.1",
+        "@smithy/types": "^2.3.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -3577,11 +4101,12 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.4.tgz",
-      "integrity": "sha512-JtKWIKoCFeOY5JGQeEl81AKdIpzeLLSjSMmO5yoKqc58Yn3cxmteylT6Elba3FgAHjK1OthARRXz5JXaKKRB7g==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.7.tgz",
+      "integrity": "sha512-J4J1AWiqaApC+3I9U++SuxAQ3BOoM5VoYnpFzCZcb63aLF80Zpc/nq2pFR1OsEIYyg2UYNdcBKKfHABmwo4WgQ==",
       "dependencies": {
-        "@smithy/types": "^2.2.1",
+        "@smithy/node-config-provider": "^2.0.9",
+        "@smithy/types": "^2.3.0",
         "@smithy/util-config-provider": "^2.0.0",
         "@smithy/util-middleware": "^2.0.0",
         "tslib": "^2.5.0"
@@ -3591,14 +4116,14 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.4.tgz",
-      "integrity": "sha512-vW7xoDKZwjjf/2GCwVf/uvZce/QJOAYan9r8UsqlzOrnnpeS2ffhxeZjLK0/emZu8n6qU3amGgZ/BTo3oVtEyQ==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.9.tgz",
+      "integrity": "sha512-K7WZRkHS5HZofRgK+O8W4YXXyaVexU1K6hp9vlUL/8CsnrFbZS9quyH/6hTROrYh2PuJr24yii1kc83NJdxMGQ==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.0.4",
-        "@smithy/property-provider": "^2.0.4",
-        "@smithy/types": "^2.2.1",
-        "@smithy/url-parser": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.9",
+        "@smithy/property-provider": "^2.0.7",
+        "@smithy/types": "^2.3.0",
+        "@smithy/url-parser": "^2.0.6",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -3668,15 +4193,27 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.0.4.tgz",
-      "integrity": "sha512-1dwR8T+QMe5Gs60NpZgF7ReZp0SXz1O/aX5BdDhsOJh72fi3Bx2UZlDihCdb++9vPyBRMXFRF7I8/C4x8iIm8A==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.1.2.tgz",
+      "integrity": "sha512-3Gm3pQm4viUPU+e7KkRScS9t5phBxSNRS8rQSZ+HeCwK/busrX0/2HJZiwLvGblqPqi1laJB0lD18AdiOioJww==",
       "dependencies": {
-        "@smithy/protocol-http": "^2.0.4",
-        "@smithy/querystring-builder": "^2.0.4",
-        "@smithy/types": "^2.2.1",
+        "@smithy/protocol-http": "^3.0.2",
+        "@smithy/querystring-builder": "^2.0.6",
+        "@smithy/types": "^2.3.0",
         "@smithy/util-base64": "^2.0.0",
         "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/protocol-http": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.2.tgz",
+      "integrity": "sha512-LUOWCPRihvJBkdSs+ivK9m1f/rMfF3n9Zpzg8qdry2eIG4HQqqLBMWQyF9bgk7JhsrrOa3//jJKhXzvL7wL5Xw==",
+      "dependencies": {
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/hash-blob-browser": {
@@ -3691,11 +4228,11 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.4.tgz",
-      "integrity": "sha512-vZ6a/fvEAFJKNtxJsn0I2WM8uBdypLLhLTpP4BA6fRsBAtwIl5S4wTt0Hspy6uGNn/74LmCxGmFSTMMbSd7ZDA==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.6.tgz",
+      "integrity": "sha512-xz7fzFxSzxohKGGyKPbLReRrY01JOZgRDHIXSks3PxQxG9c8PJMa5nUw0stH8UOySUgkofmMy0n7vTUsF5Mdqg==",
       "dependencies": {
-        "@smithy/types": "^2.2.1",
+        "@smithy/types": "^2.3.0",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
@@ -3718,11 +4255,11 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.4.tgz",
-      "integrity": "sha512-zfbPPZFiZvhIXJYKlzQwDUnxmWK/SmyDcM6iQJRZHU2jQZAzhHUXFGIu2lKH9L02VUqysOgQi3S/HY4fhrVT8w==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.6.tgz",
+      "integrity": "sha512-L5MUyl9mzawIvBxr0Hg3J/Q5qZFXKcBgMk0PacfK3Mthp4WAR6h7iMxdSQ23Q7X/kxOrpZuoYEdh1BWLKbDc8Q==",
       "dependencies": {
-        "@smithy/types": "^2.2.1",
+        "@smithy/types": "^2.3.0",
         "tslib": "^2.5.0"
       }
     },
@@ -3748,12 +4285,24 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.4.tgz",
-      "integrity": "sha512-Pdd+fhRbvizqsgYJ0pLWE6hjhq42wDFWzMj/1T7mEY9tG9bP6/AcdsQK8SAOckrBLURDoeSqTAwPKalsgcZBxw==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.8.tgz",
+      "integrity": "sha512-fHJFsscHXrYhUSWMFJNXfsZW8KsyhWQfBgU3b0nvDfpm+NAeQLqKYNhywGrDwZQc1k+lt7Fw9faAquhNPxTZRA==",
       "dependencies": {
-        "@smithy/protocol-http": "^2.0.4",
-        "@smithy/types": "^2.2.1",
+        "@smithy/protocol-http": "^3.0.2",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length/node_modules/@smithy/protocol-http": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.2.tgz",
+      "integrity": "sha512-LUOWCPRihvJBkdSs+ivK9m1f/rMfF3n9Zpzg8qdry2eIG4HQqqLBMWQyF9bgk7JhsrrOa3//jJKhXzvL7wL5Xw==",
+      "dependencies": {
+        "@smithy/types": "^2.3.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -3761,13 +4310,13 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.4.tgz",
-      "integrity": "sha512-aLPqkqKjZQ1V718P0Ostpp53nWfwK32uD0HFKSAOT25RvL285dqzGl0PAKDXpyLsPsPmHe0Yrg0AUFkRv4CRbQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.6.tgz",
+      "integrity": "sha512-MuSPPtEHFal/M77tR3ffLsdOfX29IZpA990nGuoPj5zQnAYrA4PYBGoqqrASQKm8Xb3C0NwuYzOATT7WX4f5Pg==",
       "dependencies": {
-        "@smithy/middleware-serde": "^2.0.4",
-        "@smithy/types": "^2.2.1",
-        "@smithy/url-parser": "^2.0.4",
+        "@smithy/middleware-serde": "^2.0.6",
+        "@smithy/types": "^2.3.0",
+        "@smithy/url-parser": "^2.0.6",
         "@smithy/util-middleware": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -3776,17 +4325,30 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.4.tgz",
-      "integrity": "sha512-stozO6NgH9W/OSfFMOJEtlJCsnJFSoGyV4LHzIVQeXTzZ2RHjmytQ/Ez7GngHGZ1YsB4zxE1qDTXAU0AlaKf2w==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.9.tgz",
+      "integrity": "sha512-gneEqWj4l/ZjHdZPk0BFMXoTalRArdQ8i579/KqJgBAc6Ux5vnR/SSppkMCkj2kOQYwdypvzSPeqEW3ZrvIg6g==",
       "dependencies": {
-        "@smithy/protocol-http": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.9",
+        "@smithy/protocol-http": "^3.0.2",
         "@smithy/service-error-classification": "^2.0.0",
-        "@smithy/types": "^2.2.1",
+        "@smithy/types": "^2.3.0",
         "@smithy/util-middleware": "^2.0.0",
         "@smithy/util-retry": "^2.0.0",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry/node_modules/@smithy/protocol-http": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.2.tgz",
+      "integrity": "sha512-LUOWCPRihvJBkdSs+ivK9m1f/rMfF3n9Zpzg8qdry2eIG4HQqqLBMWQyF9bgk7JhsrrOa3//jJKhXzvL7wL5Xw==",
+      "dependencies": {
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -3801,11 +4363,11 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.4.tgz",
-      "integrity": "sha512-oDttJMMES7yXmopjQHnqTkxu8vZOdjB9VpSj94Ff4/GXdKQH7ozKLNIPq4C568nbeQbBt/gsLb6Ttbx1+j+JPQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.6.tgz",
+      "integrity": "sha512-8/GODBngYbrS28CMZtaHIL4R9rLNSQ/zgb+N1OAZ02NwBUawlnLDcatve9YRzhJC/IWz0/pt+WimJZaO1sGcig==",
       "dependencies": {
-        "@smithy/types": "^2.2.1",
+        "@smithy/types": "^2.3.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -3824,13 +4386,13 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.4.tgz",
-      "integrity": "sha512-s9O90cEhkpzZulvdHBBaroZ6AJ5uV6qtmycgYKP1yOCSfPHGIWYwaULdbfxraUsvzCcnMosDNkfckqXYoKI6jw==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.9.tgz",
+      "integrity": "sha512-TlSPbCwtT/jgNnmPQqKuCR5CFN8UIrCCHRrgUfs3NqRMuaLLeP8TPe1fSKq2J8h1M/jd4BF853gneles0gWevg==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.4",
-        "@smithy/shared-ini-file-loader": "^2.0.4",
-        "@smithy/types": "^2.2.1",
+        "@smithy/property-provider": "^2.0.7",
+        "@smithy/shared-ini-file-loader": "^2.0.8",
+        "@smithy/types": "^2.3.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -3838,14 +4400,26 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.0.4.tgz",
-      "integrity": "sha512-svqeqkGgQz1B2m3IurHtp1O8vfuUGbqw6vynFmOrvPirRdiIPukHTZW1GN/JuBCtDpq9mNPutSVipfz2n4sZbQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.2.tgz",
+      "integrity": "sha512-PdEEDCShuM8zxGoaRxmGB/1ikB8oeqz+ZAF9VIA8FCP3E59j8zDTF+wCELoWd1Y6gtxr+RcTAg5sA8nvn5qH/w==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.4",
-        "@smithy/protocol-http": "^2.0.4",
-        "@smithy/querystring-builder": "^2.0.4",
-        "@smithy/types": "^2.2.1",
+        "@smithy/abort-controller": "^2.0.6",
+        "@smithy/protocol-http": "^3.0.2",
+        "@smithy/querystring-builder": "^2.0.6",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler/node_modules/@smithy/protocol-http": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.2.tgz",
+      "integrity": "sha512-LUOWCPRihvJBkdSs+ivK9m1f/rMfF3n9Zpzg8qdry2eIG4HQqqLBMWQyF9bgk7JhsrrOa3//jJKhXzvL7wL5Xw==",
+      "dependencies": {
+        "@smithy/types": "^2.3.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -3853,11 +4427,11 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.4.tgz",
-      "integrity": "sha512-OfaUIhnyvOkuCPHWMPkJqX++dUaDKsiZWuZqCdU04Z9dNAl2TtZAh7dw2rsZGb57vq6YH3PierNrDfQJTAKYtg==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.7.tgz",
+      "integrity": "sha512-XT8Tl7YNxM8tCtGqy7v7DSf6PxyXaPE9cdA/Yj4dEw2b05V3RrPqsP+t5XJiZu0yIsQ7pdeYZWv2sSEWVjNeAg==",
       "dependencies": {
-        "@smithy/types": "^2.2.1",
+        "@smithy/types": "^2.3.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -3877,11 +4451,11 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.4.tgz",
-      "integrity": "sha512-Jc7UPx1pNeisYcABkoo2Pn4kvomy1UI7uxv7R+1W3806KMAKgYHutWmZG01aPHu2XH0zY2RF2KfGiuialsxHvA==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.6.tgz",
+      "integrity": "sha512-HnU00shCGoV8vKJZTiNBkNvR9NogU3NIUaVMAGJPSqNGJj3psWo+TUrC0BVCDcwiCljXwXCFGJqIcsWtClrktQ==",
       "dependencies": {
-        "@smithy/types": "^2.2.1",
+        "@smithy/types": "^2.3.0",
         "@smithy/util-uri-escape": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -3890,11 +4464,11 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.4.tgz",
-      "integrity": "sha512-Uh6+PhGxSo17qe2g/JlyoekvTHKn7dYWfmHqUzPAvkW+dHlc3DNVG3++PV48z33lCo5YDVBBturWQ9N/TKn+EA==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.6.tgz",
+      "integrity": "sha512-i4LKoXHP7pTFAPjLIJyQXYOhWokbcFha3WWsX74sAKmuluv0XM2cxONZoFxwEzmWhsNyM6buSwJSZXyPiec0AQ==",
       "dependencies": {
-        "@smithy/types": "^2.2.1",
+        "@smithy/types": "^2.3.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -3910,11 +4484,11 @@
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.4.tgz",
-      "integrity": "sha512-091yneupXnSqvAU+vLG7h0g4QRRO6TjulpECXYVU6yW/LiNp7QE533DBpaphmbtI6tTC4EfGrhn35gTa0w+GQg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.8.tgz",
+      "integrity": "sha512-4u+V+Dv7JGpJ0tppB5rxCem7WhdFux950z4cGPhV0kHTPkKe8DDgINzOlVa2RBu5dI33D02OBJcxFjhW4FPORg==",
       "dependencies": {
-        "@smithy/types": "^2.2.1",
+        "@smithy/types": "^2.3.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -3940,13 +4514,13 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.0.4.tgz",
-      "integrity": "sha512-Dg1dkqyj3jwa03RFs6E4ASmfQ7CjplbGISJIJNSt3F8NfIid2RalbeCMOIHK7VagKh9qngZNyoKxObZC9LB9Lg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.3.tgz",
+      "integrity": "sha512-nSMMp2AKqcG/ruzCY01ogrMdbq/WS1cvGStTsw7yd6bTpp/bGtlOgXvy3h7e0zP7w2DH1AtvIwzYBD6ejZePsQ==",
       "dependencies": {
         "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/types": "^2.2.1",
-        "@smithy/util-stream": "^2.0.4",
+        "@smithy/types": "^2.3.0",
+        "@smithy/util-stream": "^2.0.9",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -3954,9 +4528,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.1.tgz",
-      "integrity": "sha512-6nyDOf027ZeJiQVm6PXmLm7dR+hR2YJUkr4VwUniXA8xZUGAu5Mk0zfx2BPFrt+e5YauvlIqQoH0CsrM4tLkfg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.3.0.tgz",
+      "integrity": "sha512-pJce3rd39MElkV57UTPAoSYAApjQLELUxjU5adHNLYk9gnPvyIGbJNJTZVVFu00BrgZH3W/cQe8QuFcknDyodQ==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -3965,12 +4539,12 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.4.tgz",
-      "integrity": "sha512-puIQ6+TJpI2AAPw7IGdGG6d2DEcVP5nJqa1VjrxzUcy2Jx7LtGn+gDHY2o9Pc9vQkmoicovTEKgvv7CdqP+0gg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.6.tgz",
+      "integrity": "sha512-9i6j5QW6bapHZ4rtkXOAm0hOUG1+5IVdVJXNSUTcNskwJchZH5IQuDNPCbgUi/u2P8EZazKt4wXT51QxOXCz1A==",
       "dependencies": {
-        "@smithy/querystring-parser": "^2.0.4",
-        "@smithy/types": "^2.2.1",
+        "@smithy/querystring-parser": "^2.0.6",
+        "@smithy/types": "^2.3.0",
         "tslib": "^2.5.0"
       }
     },
@@ -3995,9 +4569,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.0.0.tgz",
-      "integrity": "sha512-ZV7Z/WHTMxHJe/xL/56qZwSUcl63/5aaPAGjkfynJm4poILjdD4GmFI+V+YWabh2WJIjwTKZ5PNsuvPQKt93Mg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
+      "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -4029,12 +4603,12 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.4.tgz",
-      "integrity": "sha512-wGdnPt4Ng72duUd97HrlqVkq6DKVB/yjaGkSg5n3uuQKzzHjoi3OdjXGumD/VYPHz0dYd7wpLNG2CnMm/nfDrg==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.7.tgz",
+      "integrity": "sha512-s1caKxC7Y87Q72Goll//clZs2WNBfG9WtFDWVRS+Qgk147YPCOUYtkpuD0XZAh/vbayObFz5tQ1fiX4G19HSCA==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.4",
-        "@smithy/types": "^2.2.1",
+        "@smithy/property-provider": "^2.0.7",
+        "@smithy/types": "^2.3.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       },
@@ -4043,15 +4617,15 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.4.tgz",
-      "integrity": "sha512-QMkNcV6x52BeeeIvhvow6UmOu7nP7DXQljY6DKOP/aAokrli53IWTP/kUTd9B0Mp9tbW3WC10O6zaM69xiMNYw==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.9.tgz",
+      "integrity": "sha512-HlV4iNL3/PgPpmDGs0+XrAKtwFQ8rOs5P2y5Dye8dUYaJauadlzHRrNKk7wH2aBYswvT2HM+PIgXamvrE7xbcw==",
       "dependencies": {
-        "@smithy/config-resolver": "^2.0.4",
-        "@smithy/credential-provider-imds": "^2.0.4",
-        "@smithy/node-config-provider": "^2.0.4",
-        "@smithy/property-provider": "^2.0.4",
-        "@smithy/types": "^2.2.1",
+        "@smithy/config-resolver": "^2.0.7",
+        "@smithy/credential-provider-imds": "^2.0.9",
+        "@smithy/node-config-provider": "^2.0.9",
+        "@smithy/property-provider": "^2.0.7",
+        "@smithy/types": "^2.3.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4093,13 +4667,13 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.4.tgz",
-      "integrity": "sha512-ZVje79afuv3DB1Ma/g5m/5v9Zda8nA0xNgvE1pOD3EnoTp/Ekch1z20AN6gfVsf7JYWK2VSMVDiqI9N8Ua4wbg==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.9.tgz",
+      "integrity": "sha512-Fn2/3IMwqu0l2hOC7K3bbtSqFEJ6nOzMLoPVIhuH84yw/95itNkFBwVbIIiAfDaout0ZfZ26+5ch86E2q3avww==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^2.0.4",
-        "@smithy/node-http-handler": "^2.0.4",
-        "@smithy/types": "^2.2.1",
+        "@smithy/fetch-http-handler": "^2.1.2",
+        "@smithy/node-http-handler": "^2.1.2",
+        "@smithy/types": "^2.3.0",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-hex-encoding": "^2.0.0",
@@ -4134,12 +4708,12 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.4.tgz",
-      "integrity": "sha512-NAzHgewL+sIJw9vlgR4m8btJiu1u0vuQRNRT7Bd5B66h02deFMmOaw1zeGePORZa7zyUwNZ2J5ZPkKzq4ced7Q==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.6.tgz",
+      "integrity": "sha512-wjxvKB4XSfgpOg3lr4RulnVhd21fMMC4CPARBwrSN7+3U28fwOifv8f7T+Ibay9DAQTj9qXxmd8ag6WXBRgNhg==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.4",
-        "@smithy/types": "^2.2.1",
+        "@smithy/abort-controller": "^2.0.6",
+        "@smithy/types": "^2.3.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4207,6 +4781,15 @@
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/@types/ssh2-streams/-/ssh2-streams-0.1.9.tgz",
       "integrity": "sha512-I2J9jKqfmvXLR5GomDiCoHrEJ58hAOmFrekfFqmCFd+A6gaEStvWnPykoWUwld1PNg4G5ag1LwdA+Lz1doRJqg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/varint": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/varint/-/varint-6.0.1.tgz",
+      "integrity": "sha512-fQdOiZpDMBvaEdl12P1x7xlTPRAtd7qUUtVaWgkCy8DC//wCv19nqFFtrnR3y/ac6VFY0UUvYuQqfKzZTSE26w==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -12323,20 +12906,31 @@
       "name": "@sha256it/functions",
       "version": "0.0.0",
       "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.410.0",
         "@aws-sdk/client-s3": "^3.383.0",
+        "@aws-sdk/util-dynamodb": "^3.410.0",
         "cardex": "^2.3.1",
         "carstream": "^1.1.0",
         "multiformats": "^12.0.1",
-        "uint8arraylist": "^2.4.3"
+        "p-retry": "^6.0.0",
+        "parallel-transform-web": "^1.0.0",
+        "uint8arraylist": "^2.4.3",
+        "varint": "^6.0.0"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.119",
         "@types/node": "^20.4.7",
+        "@types/varint": "^6.0.1",
         "nanoid": "^4.0.2",
         "sst": "^2.23.1",
         "testcontainers": "^10.2.1",
         "vitest": "^0.34.1"
       }
+    },
+    "packages/functions/node_modules/@types/retry": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow=="
     },
     "packages/functions/node_modules/nanoid": {
       "version": "4.0.2",
@@ -12354,6 +12948,21 @@
       },
       "engines": {
         "node": "^14 || ^16 || >=18"
+      }
+    },
+    "packages/functions/node_modules/p-retry": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.0.0.tgz",
+      "integrity": "sha512-6NuuXu8Upembd4sNdo4PRbs+M6aHgBTrFE6lkH0YKjVzne3cDW4gkncB98ty/bkMxLxLVNeD5bX9FyWjM7WZ+A==",
+      "dependencies": {
+        "@types/retry": "0.12.2",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -9,16 +9,22 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.119",
     "@types/node": "^20.4.7",
+    "@types/varint": "^6.0.1",
     "nanoid": "^4.0.2",
     "sst": "^2.23.1",
     "testcontainers": "^10.2.1",
     "vitest": "^0.34.1"
   },
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.410.0",
     "@aws-sdk/client-s3": "^3.383.0",
+    "@aws-sdk/util-dynamodb": "^3.410.0",
     "cardex": "^2.3.1",
     "carstream": "^1.1.0",
     "multiformats": "^12.0.1",
-    "uint8arraylist": "^2.4.3"
+    "p-retry": "^6.0.0",
+    "parallel-transform-web": "^1.0.0",
+    "uint8arraylist": "^2.4.3",
+    "varint": "^6.0.0"
   }
 }

--- a/packages/functions/src/copy.ts
+++ b/packages/functions/src/copy.ts
@@ -12,34 +12,11 @@ import { Uint8ArrayList } from 'uint8arraylist'
 import { CARReaderStream } from 'carstream'
 import { MultihashIndexSortedWriter } from 'cardex/multihash-index-sorted'
 import { mustGetEnv, errorResponse } from './lib/util'
+import { ShardLink, ObjectID, ContentAddressedObjectID, ShardObjectID } from './lib/api.js'
+import { CAR_CODEC } from './lib/constants.js'
 
-const CAR_CODEC = 0x0202
 const MAX_PUT_SIZE = 1024 * 1024 * 1024 * 5
 const TARGET_PART_SIZE = 1024 * 1024 * 100
-
-type ShardLink = Link.Link<Uint8Array, typeof CAR_CODEC>
-
-interface ObjectID {
-  region: string
-  bucket: string
-  key: string
-  endpoint?: string
-  credentials?: {
-    accessKeyId: string,
-    secretAccessKey: string
-  }
-}
-
-interface ContentAddressedObjectID<
-  Data extends unknown = unknown,
-  Format extends number = number,
-  Alg extends number = number,
-  V extends Link.Version = 1
-> extends ObjectID {
-  cid: Link.Link<Data, Format, Alg, V>
-}
-
-interface ShardObjectID extends ContentAddressedObjectID<Uint8Array, typeof CAR_CODEC> {}
 
 interface ShardSource extends ContentAddressedObjectID<Uint8Array, typeof CAR_CODEC> {
   size: number

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -1,0 +1,186 @@
+import { ApiHandler } from 'sst/node/api'
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { MultihashDigest } from 'multiformats'
+import * as Link from 'multiformats/link'
+import { base58btc } from 'multiformats/bases/base58'
+import { CARReaderStream } from 'carstream'
+import { mustGetEnv, errorResponse } from './lib/util'
+import { BatchGetItemCommand, BatchWriteItemCommand, DynamoDBClient, WriteRequest } from '@aws-sdk/client-dynamodb'
+import { Block, Position } from 'carstream/api'
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
+import retry from 'p-retry'
+import { Parallel } from 'parallel-transform-web'
+import { MultihashIndexSortedReader } from 'cardex/multihash-index-sorted'
+import { Credentials, Endpoint, ShardLink, ShardObjectID } from './lib/api.js'
+import { CAR_CODEC } from './lib/constants.js'
+
+interface TableID extends Endpoint, Credentials {
+  tableName: string
+}
+
+export const handler = ApiHandler(event => _handler.call(null, new Request(`http://localhost/?${event.rawQueryString}`), process.env))
+
+export const _handler = async (request: Request, env: Record<string, string|undefined>) => {
+  try {
+    const { searchParams } = new URL(request.url)
+
+    const srcRegion = searchParams.get('region')
+    if (!srcRegion) return errorResponse('Missing "region" search parameter', 400)
+    if (!['us-east-2', 'us-west-2'].includes(srcRegion)) return errorResponse('Invalid region', 400)
+
+    const srcBucketName = searchParams.get('bucket')
+    if (!srcBucketName) return errorResponse('Missing "bucket" search parameter', 400)
+    if (!srcBucketName.startsWith('dotstorage')) return errorResponse('Invalid bucket', 400)
+
+    const srcKey = searchParams.get('key')
+    if (!srcKey) return errorResponse('Missing "key" search parameter', 400)
+    if (!srcKey.endsWith('.car')) return errorResponse('Only keys for CARs supported', 400)
+
+    const shardstr = searchParams.get('shard')
+    if (!shardstr) return errorResponse('Missing "shard" search parameter', 400)
+    const shard: ShardLink = Link.parse(shardstr)
+    if (shard.code !== CAR_CODEC) return errorResponse('Not a CAR file hash', 400)
+
+    const src = {
+      cid: shard,
+      region: srcRegion,
+      bucket: srcBucketName,
+      key: srcKey
+    }
+
+    const dest = { tableName: mustGetEnv(env, 'BLOCK_INDEX_TABLE') }
+
+    return await index(src, dest)
+  } catch (err: any) {
+    console.error(err)
+    return errorResponse(err.message, 500)
+  }
+}
+
+class Batcher<I> extends TransformStream<I, I[]> {
+  constructor (size: number) {
+    let batch: I[] = []
+    super({
+      transform (chunk, controller) {
+        batch.push(chunk)
+        if (batch.length < size) return
+        controller.enqueue(batch)
+        batch = []
+      },
+      flush (controller) {
+        if (batch.length) controller.enqueue(batch)
+        batch = []
+      }
+    })
+  }
+}
+
+interface BlockIndexItem {
+  blockmultihash: string
+  carpath: string
+  offset: number
+  length: number
+}
+
+export const index = async (src: ShardObjectID, dest: TableID) => {
+  const dynamo = new DynamoDBClient(dest)
+  const multihashes = await shardMultihashes(src)
+  let total = 0
+  await multihashes
+    .pipeThrough(new Batcher(100))
+    .pipeThrough(new TransformStream<MultihashDigest[], BlockIndexItem>({
+      async transform (batch, controller) {
+        const cmd = new BatchGetItemCommand({
+          RequestItems: {
+            [dest.tableName]: {
+              Keys: batch.map(multihash => marshall({
+                blockmultihash: base58btc.encode(multihash.bytes),
+                carpath: `${src.region}/${src.bucket}/${src.key}`
+              }))
+            }
+          }
+        })
+        const res = await dynamo.send(cmd)
+        for (const item of res.Responses?.[dest.tableName] ?? []) {
+          controller.enqueue(unmarshall(item) as BlockIndexItem)
+        }
+      }
+    }))
+    .pipeThrough(new Batcher(25))
+    .pipeThrough(new Parallel(5, async batch => {
+      const writeItems = (items: WriteRequest[]) => retry(async () => {
+        const cmd = new BatchWriteItemCommand({ RequestItems: { [dest.tableName]: items } })
+        const res = await dynamo.send(cmd)
+        if (res.UnprocessedItems && res.UnprocessedItems[dest.tableName]?.length) {
+          items = res.UnprocessedItems[dest.tableName]
+          throw new Error(`${res.UnprocessedItems[dest.tableName].length} unprocessed items`)
+        }
+      }, { retries: 2 })
+
+      let items: WriteRequest[] = batch.map(b => {
+        const item = { ...b, carpath: `auto/carpark-prod-0/${src.cid}/${src.cid}.car` }
+        console.warn('write', JSON.stringify(item))
+        return { PutRequest: { Item: marshall(item) } }
+      })
+
+      // write new items
+      await writeItems(items)
+
+      items = batch.map(b => {
+        const key = { blockmultihash: b.blockmultihash, carpath: b.carpath }
+        console.warn('delete', JSON.stringify(key))
+        return { DeleteRequest: { Key: marshall(key) } }
+      })
+
+      // delete old items
+      await writeItems(items)
+
+      return batch.length
+    }))
+    .pipeTo(new WritableStream({
+      async write (updated) {
+        total += updated
+      }
+    }))
+
+  return { statusCode: 200, body: JSON.stringify({ ok: true, updated: total }) }
+}
+
+/** Retrieve multihashes of blocks in the CAR. */
+const shardMultihashes = async (src: ShardObjectID): Promise<ReadableStream<MultihashDigest>> => {
+  const s3 = new S3Client(src)
+  try {
+    const cmd = new GetObjectCommand({ Bucket: src.bucket, Key: `${src.key}.idx` })
+    const res = await s3.send(cmd)
+    if (!res.Body) throw new Error('missing body')
+    const reader = MultihashIndexSortedReader.createReader({ reader: res.Body.transformToWebStream().getReader() })
+    return new ReadableStream({
+      async pull (controller) {
+        const { done, value } = await reader.read()
+        if (done) return controller.close()
+        controller.enqueue(value.multihash)
+      }
+    })
+  } catch (err: any) {
+    if (err.$metadata?.httpStatusCode !== 404) {
+      console.error(`failed to read index: ${src.key}.idx`, err)
+      throw new Error(`failed to read index: ${src.key}.idx`, { cause: err })
+    }
+  }
+
+  const blocks = await shardBlocks(src)
+  return blocks.pipeThrough(new TransformStream({
+    transform (block, controller) {
+      controller.enqueue(block.cid.multihash)
+    }
+  }))
+}
+
+/** Retrieve blocks from the CAR. */
+const shardBlocks = async (src: ShardObjectID): Promise<ReadableStream<Block & Position>> => {
+  const s3 = new S3Client(src)
+  const cmd = new GetObjectCommand({ Bucket: src.bucket, Key: src.key })
+  const res = await s3.send(cmd)
+  if (!res.Body) throw new Error('missing body')
+  return res.Body.transformToWebStream().pipeThrough(new CARReaderStream())
+}

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -48,7 +48,10 @@ export const _handler = async (request: Request, env: Record<string, string|unde
       key: srcKey
     }
 
-    const dest = { tableName: mustGetEnv(env, 'BLOCK_INDEX_TABLE') }
+    const dest = {
+      region: mustGetEnv(env, 'BLOCK_INDEX_REGION'),
+      tableName: mustGetEnv(env, 'BLOCK_INDEX_TABLE')
+    }
 
     return await index(src, dest)
   } catch (err: any) {

--- a/packages/functions/src/lib/api.ts
+++ b/packages/functions/src/lib/api.ts
@@ -1,0 +1,32 @@
+import { Link, Version } from 'multiformats'
+import { CAR_CODEC } from './constants.js'
+
+export type ShardLink = Link<Uint8Array, typeof CAR_CODEC>
+
+export interface Endpoint {
+  endpoint?: string
+}
+
+export interface Credentials {
+  credentials?: {
+    accessKeyId: string,
+    secretAccessKey: string
+  }
+}
+
+export interface ObjectID extends Endpoint, Credentials {
+  region: string
+  bucket: string
+  key: string
+}
+
+export interface ContentAddressedObjectID<
+  Data extends unknown = unknown,
+  Format extends number = number,
+  Alg extends number = number,
+  V extends Version = 1
+> extends ObjectID {
+  cid: Link<Data, Format, Alg, V>
+}
+
+export interface ShardObjectID extends ContentAddressedObjectID<Uint8Array, typeof CAR_CODEC> {}

--- a/packages/functions/src/lib/constants.ts
+++ b/packages/functions/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const CAR_CODEC = 0x0202

--- a/packages/functions/test/helpers/aws.ts
+++ b/packages/functions/test/helpers/aws.ts
@@ -1,6 +1,8 @@
 import { GenericContainer, StartedTestContainer } from 'testcontainers'
 import { customAlphabet } from 'nanoid'
 import { S3Client, CreateBucketCommand, HeadObjectCommand } from '@aws-sdk/client-s3'
+import { CreateTableCommand, DynamoDBClient, GetItemCommand } from '@aws-sdk/client-dynamodb'
+import { marshall } from '@aws-sdk/util-dynamodb'
 
 const id = customAlphabet('1234567890abcdefghijklmnopqrstuvwxyz', 10)
 const credentials = { accessKeyId: 'minioadmin', secretAccessKey: 'minioadmin' }
@@ -51,4 +53,55 @@ export const keyExists = async (s3: S3Client, bucket: string, key: string) => {
     }
     return false
   }
+}
+
+export async function createDynamo (opts: { port?: number, region?: string } = {}) {
+  console.log('Creating local DynamoDB...')
+  const port = opts?.port ?? 8000
+  const region = opts?.region ?? 'us-west-2'
+  const container = await new GenericContainer('amazon/dynamodb-local:latest')
+    .withExposedPorts(port)
+    .start()
+
+  const clientOpts = {
+    endpoint: `http://127.0.0.1:${container.getMappedPort(8000)}`,
+    region,
+    credentials
+  }
+
+  return { container, client: new DynamoDBClient(clientOpts), ...clientOpts }
+}
+
+export async function createDynamoTable (dynamo: DynamoDBClient, pfx = '') {
+  const name = (pfx ? `${pfx}-` : '') + id()
+  console.log(`Creating DynamoDB table "${name}"...`)
+
+  await dynamo.send(
+    new CreateTableCommand({
+      TableName: name,
+      AttributeDefinitions: [
+        { AttributeName: 'blockmultihash', AttributeType: 'S' },
+        { AttributeName: 'carpath', AttributeType: 'S' }
+      ],
+      KeySchema: [
+        { AttributeName: 'blockmultihash', KeyType: 'HASH' },
+        { AttributeName: 'carpath', KeyType: 'RANGE' }
+      ],
+      ProvisionedThroughput: {
+        ReadCapacityUnits: 1,
+        WriteCapacityUnits: 1
+      }
+    })
+  )
+
+  return name
+}
+
+export const itemExists = async <T>(dynamo: DynamoDBClient, tableName: string, key: T) => {
+  const cmd = new GetItemCommand({
+    TableName: tableName,
+    Key: marshall(key)
+  })
+  const res = await dynamo.send(cmd)
+  return Boolean(res.Item)
 }

--- a/packages/functions/test/index.test.ts
+++ b/packages/functions/test/index.test.ts
@@ -1,0 +1,228 @@
+import { expect, test, beforeAll, beforeEach, afterAll, afterEach, Nullable } from 'vitest'
+import fs from 'node:fs'
+import { Readable } from 'node:stream'
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { DynamoDBClient, GetItemCommand, PutItemCommand } from '@aws-sdk/client-dynamodb'
+import { marshall } from '@aws-sdk/util-dynamodb'
+import { UnknownLink, Link } from 'multiformats'
+import { base58btc } from 'multiformats/bases/base58'
+import { CARReaderStream } from 'carstream'
+import { Block, Position } from 'carstream/api'
+import varint from 'varint'
+import { TestAWSService, createDynamo, createDynamoTable, createS3, createS3Bucket, itemExists, keyExists } from './helpers/aws'
+import { generateTestCAR, writeCARIndex } from './helpers/car'
+import { index } from '../src/index'
+
+let s3: TestAWSService<S3Client>
+let dynamo: TestAWSService<DynamoDBClient>
+let srcBucket: string
+let blockIndexTable: string
+let srcCAR: Nullable<{ cid: Link<Uint8Array, 0x0202>, root: UnknownLink, size: number, path: string }>
+let srcIndex: Nullable<{ size: number, path: string, items: Array<{ cid: UnknownLink } & Position> }>
+
+beforeAll(async () => {
+  s3 = await createS3()
+  dynamo = await createDynamo()
+})
+
+beforeEach(async () => {
+  srcBucket = await createS3Bucket(s3.client, 'src')
+  blockIndexTable = await createDynamoTable(dynamo.client, 'blocks-cars-position')
+  srcCAR = null
+  srcIndex = null
+})
+
+afterEach(async () => {
+  if (srcCAR) await fs.promises.rm(srcCAR.path)
+  if (srcIndex) await fs.promises.rm(srcIndex.path)
+})
+
+afterAll(async () => {
+  await s3.container.stop()
+  await dynamo.container.stop()
+})
+
+const toBlockIndexItem = (block: Block & Position, region: string, bucket: string, key: string) => {
+  const blockHeaderLength = varint.encodingLength(block.length) + block.cid.bytes.length
+  return {
+    carpath: `${region}/${bucket}/${key}`,
+    blockmultihash: base58btc.encode(block.cid.multihash.bytes),
+    offset: block.offset + blockHeaderLength,
+    length: block.length - blockHeaderLength
+  }
+}
+
+test('index a CAR with CARv2 side index', async () => {
+  srcCAR = await generateTestCAR(50 * 1024 * 1024)
+  srcIndex = await writeCARIndex(srcCAR.path, `${srcCAR.path}.idx`)
+
+  const srcCARKey = `complete/${srcCAR.root}.car`
+  await s3.client.send(new PutObjectCommand({
+    Bucket: srcBucket,
+    Key: srcCARKey,
+    ContentLength: srcCAR.size,
+    Body: fs.createReadStream(srcCAR.path)
+  }))
+
+  const srcIndexKey = `complete/${srcCAR.root}.car.idx`
+  await s3.client.send(new PutObjectCommand({
+    Bucket: srcBucket,
+    Key: srcIndexKey,
+    ContentLength: srcIndex.size,
+    Body: fs.createReadStream(srcIndex.path)
+  }))
+
+  const stream = Readable.toWeb(fs.createReadStream(srcCAR.path)) as ReadableStream<Uint8Array>
+  await stream
+    .pipeThrough(new CARReaderStream())
+    .pipeTo(new WritableStream({
+      async write (block) {
+        await dynamo.client.send(new PutItemCommand({
+          TableName: blockIndexTable,
+          Item: marshall(toBlockIndexItem(block, s3.region, srcBucket, srcCARKey))
+        }))
+      }
+    }))
+
+  const res = await index({
+    ...s3,
+    cid: srcCAR.cid,
+    bucket: srcBucket,
+    key: srcCARKey
+  }, {
+    ...dynamo,
+    tableName: blockIndexTable
+  })
+  expect(res.statusCode).toBe(200)
+
+  const { ok, updated } = JSON.parse(res.body)
+  expect(ok).toBe(true)
+  expect(updated).toBe(srcIndex.items.length)
+
+  for (const item of srcIndex.items) {
+    const blockmultihash = base58btc.encode(item.cid.multihash.bytes)
+    await expect(itemExists(dynamo.client, blockIndexTable, {
+      blockmultihash,
+      carpath: `auto/carpark-prod-0/${srcCAR.cid}/${srcCAR.cid}.car`
+    })).resolves.toBe(true)
+    await expect(itemExists(dynamo.client, blockIndexTable, {
+      blockmultihash,
+      carpath: `${s3.region}/${srcBucket}/${srcCARKey}`
+    })).resolves.toBe(false)
+  }
+})
+
+test('index a CAR without CARv2 side index', async () => {
+  srcCAR = await generateTestCAR(50 * 1024 * 1024)
+
+  const srcCARKey = `complete/${srcCAR.root}.car`
+  await s3.client.send(new PutObjectCommand({
+    Bucket: srcBucket,
+    Key: srcCARKey,
+    ContentLength: srcCAR.size,
+    Body: fs.createReadStream(srcCAR.path)
+  }))
+
+  const blocks: Block[] = []
+  const stream = Readable.toWeb(fs.createReadStream(srcCAR.path)) as ReadableStream<Uint8Array>
+  await stream
+    .pipeThrough(new CARReaderStream())
+    .pipeTo(new WritableStream({
+      async write (block) {
+        blocks.push(block)
+        await dynamo.client.send(new PutItemCommand({
+          TableName: blockIndexTable,
+          Item: marshall(toBlockIndexItem(block, s3.region, srcBucket, srcCARKey))
+        }))
+      }
+    }))
+
+  const res = await index({
+    ...s3,
+    cid: srcCAR.cid,
+    bucket: srcBucket,
+    key: srcCARKey
+  }, {
+    ...dynamo,
+    tableName: blockIndexTable
+  })
+  expect(res.statusCode).toBe(200)
+
+  const { ok, updated } = JSON.parse(res.body)
+  expect(ok).toBe(true)
+  expect(updated).toBe(blocks.length)
+
+  for (const block of blocks) {
+    const blockmultihash = base58btc.encode(block.cid.multihash.bytes)
+    await expect(itemExists(dynamo.client, blockIndexTable, {
+      blockmultihash,
+      carpath: `auto/carpark-prod-0/${srcCAR.cid}/${srcCAR.cid}.car`
+    })).resolves.toBe(true)
+    await expect(itemExists(dynamo.client, blockIndexTable, {
+      blockmultihash,
+      carpath: `${s3.region}/${srcBucket}/${srcCARKey}`
+    })).resolves.toBe(false)
+  }
+})
+
+test('do not touch other block index items for same multihash', async () => {
+  srcCAR = await generateTestCAR(5 * 1024 * 1024)
+
+  const srcCARKey = `complete/${srcCAR.root}.car`
+  await s3.client.send(new PutObjectCommand({
+    Bucket: srcBucket,
+    Key: srcCARKey,
+    ContentLength: srcCAR.size,
+    Body: fs.createReadStream(srcCAR.path)
+  }))
+  const altCARKey = `raw/u/${srcCAR.root}/${srcCAR.cid}.car`
+
+  const blocks: Block[] = []
+  const stream = Readable.toWeb(fs.createReadStream(srcCAR.path)) as ReadableStream<Uint8Array>
+  await stream
+    .pipeThrough(new CARReaderStream())
+    .pipeTo(new WritableStream({
+      async write (block) {
+        blocks.push(block)
+        await dynamo.client.send(new PutItemCommand({
+          TableName: blockIndexTable,
+          Item: marshall(toBlockIndexItem(block, s3.region, srcBucket, srcCARKey))
+        }))
+        await dynamo.client.send(new PutItemCommand({
+          TableName: blockIndexTable,
+          Item: marshall(toBlockIndexItem(block, s3.region, srcBucket, altCARKey))
+        }))
+      }
+    }))
+
+  const res = await index({
+    ...s3,
+    cid: srcCAR.cid,
+    bucket: srcBucket,
+    key: srcCARKey
+  }, {
+    ...dynamo,
+    tableName: blockIndexTable
+  })
+  expect(res.statusCode).toBe(200)
+
+  const { ok, updated } = JSON.parse(res.body)
+  expect(ok).toBe(true)
+  expect(updated).toBe(blocks.length)
+
+  for (const block of blocks) {
+    const blockmultihash = base58btc.encode(block.cid.multihash.bytes)
+    await expect(itemExists(dynamo.client, blockIndexTable, {
+      blockmultihash,
+      carpath: `auto/carpark-prod-0/${srcCAR.cid}/${srcCAR.cid}.car`
+    })).resolves.toBe(true)
+    await expect(itemExists(dynamo.client, blockIndexTable, {
+      blockmultihash,
+      carpath: `${s3.region}/${srcBucket}/${srcCARKey}`
+    })).resolves.toBe(false)
+    await expect(itemExists(dynamo.client, blockIndexTable, {
+      blockmultihash,
+      carpath: `${s3.region}/${srcBucket}/${altCARKey}`
+    })).resolves.toBe(true)
+  }
+})

--- a/stacks/api.ts
+++ b/stacks/api.ts
@@ -7,6 +7,7 @@ export function API ({ stack }: StackContext) {
   const CARPARK_BUCKET = mustGetEnv(process.env, 'CARPARK_BUCKET')
   const SATNAV_BUCKET = mustGetEnv(process.env, 'SATNAV_BUCKET')
   const DUDEWHERE_BUCKET = mustGetEnv(process.env, 'DUDEWHERE_BUCKET')
+  const BLOCK_INDEX_REGION = mustGetEnv(process.env, 'BLOCK_INDEX_REGION')
   const BLOCK_INDEX_TABLE = mustGetEnv(process.env, 'BLOCK_INDEX_TABLE')
 
   stack.setDefaultFunctionProps({
@@ -45,6 +46,7 @@ export function API ({ stack }: StackContext) {
     handler: 'packages/functions/src/index.handler',
     url: { cors: true, authorizer: 'none' },
     environment: {
+      BLOCK_INDEX_REGION,
       BLOCK_INDEX_TABLE
     }
   })

--- a/stacks/api.ts
+++ b/stacks/api.ts
@@ -7,6 +7,7 @@ export function API ({ stack }: StackContext) {
   const CARPARK_BUCKET = mustGetEnv(process.env, 'CARPARK_BUCKET')
   const SATNAV_BUCKET = mustGetEnv(process.env, 'SATNAV_BUCKET')
   const DUDEWHERE_BUCKET = mustGetEnv(process.env, 'DUDEWHERE_BUCKET')
+  const BLOCK_INDEX_TABLE = mustGetEnv(process.env, 'BLOCK_INDEX_TABLE')
 
   stack.setDefaultFunctionProps({
     memorySize: '1 GB',
@@ -40,8 +41,19 @@ export function API ({ stack }: StackContext) {
 
   copyFunction.attachPermissions(['s3:GetObject'])
 
+  const indexFunction = new Function(stack, 'index', {
+    handler: 'packages/functions/src/index.handler',
+    url: { cors: true, authorizer: 'none' },
+    environment: {
+      BLOCK_INDEX_TABLE
+    }
+  })
+
+  indexFunction.attachPermissions(['s3:GetObject', 'dynamodb:BatchGetItem', 'dynamodb:BatchWriteItem'])
+
   stack.addOutputs({
     hashFunctionURL: hashFunction.url,
-    copyFunctionURL: copyFunction.url
+    copyFunctionURL: copyFunction.url,
+    indexFunctionURL: indexFunction.url
   })
 }


### PR DESCRIPTION
Adds a lambda that for a given CAR and CAR CID, will:

1. Read multihashes for the CAR either by reading it's CARv2 side index or (if missing) read the CAR itself
2. Batch get from dynamo existing items for each `blockmultihash+carpath`
    1. Change `carpath` for each item to be `auto/carpark-prod-0/<CAR_CID>/<CAR_CID>.car`
    2. Batch write _new items_ with the changed `carpath`
    3. Batch delete the old items with the old `carpath`